### PR TITLE
Когда я делаю /report, то вижу таблицу с часами в которой сумма часов в нижней строке не соответствует реальной сумме часов в выведенных строках (vibe-kanban)

### DIFF
--- a/app/service/reporter.rb
+++ b/app/service/reporter.rb
@@ -44,7 +44,7 @@ class Reporter
       end
 
       t << :separator
-      t << ['All days', result[:total_by_column].values.compact.sum] + result[:columns].map { |c|
+      t << ['All days', result[:total_by_date].values.compact.sum] + result[:columns].map { |c|
         result[:total_by_column][c.to_s]
       }
     end


### PR DESCRIPTION
Например:
```
+------------+-------+----------------+------+
|       date | total | Danil Pismenny |      |
+------------+-------+----------------+------+
| 2025-10-02 |   1.0 |            1.0 |    · |
| 2025-10-01 |       |              · |    · |
| 2025-09-30 |  44.5 |              · | 44.5 |
| 2025-09-29 |  1.24 |           1.24 |    · |
+------------+-------+----------------+------+
|   All days | 77.99 |          33.49 | 44.5 |
+------------+-------+----------------+------+
```

Предположи почему это может быть и варианты решения.