### PR TITLE
fix(telegram): add auth check in UsersCommand callback queries

### DIFF
--- a/app/commands/users_command.rb
+++ b/app/commands/users_command.rb
@@ -22,7 +22,7 @@ class UsersCommand < BaseCommand
 
   def show_project_users
     if current_user.nil?
-      respond_with :message, text: 'Сначала авторизуйтесь через /start'
+      respond_with :message, text: t('errors.auth_required')
       return
     end
 
@@ -57,7 +57,7 @@ class UsersCommand < BaseCommand
 
   def users_add(project_slug = nil, username = nil, role = 'member', *)
     if current_user.nil?
-      respond_with :message, text: 'Сначала авторизуйтесь через /start'
+      respond_with :message, text: t('errors.auth_required')
       return
     end
 
@@ -157,6 +157,11 @@ class UsersCommand < BaseCommand
   end
 
   def users_add_project_callback_query(project_slug)
+    if current_user.nil?
+      edit_message :text, text: t('errors.auth_required')
+      return safe_answer_callback_query('❌ Требуется авторизация', show_alert: true)
+    end
+
     project = find_project(project_slug)
     unless project
       edit_message :text, text: 'Проект не найден'
@@ -179,6 +184,11 @@ class UsersCommand < BaseCommand
   end
 
   def users_add_role_callback_query(role)
+    if current_user.nil?
+      edit_message :text, text: t('errors.auth_required')
+      return safe_answer_callback_query('❌ Требуется авторизация', show_alert: true)
+    end
+
     safe_answer_callback_query('✅ Роль выбрана')
 
     data = telegram_session_data
@@ -194,6 +204,11 @@ class UsersCommand < BaseCommand
   end
 
   def users_list_project_callback_query(project_slug)
+    if current_user.nil?
+      edit_message :text, text: t('errors.auth_required')
+      return safe_answer_callback_query('❌ Требуется авторизация', show_alert: true)
+    end
+
     project = find_project(project_slug)
     if project
       show_users_for_project(project)

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -67,6 +67,7 @@ ru:
   telegram:
     errors:
       developer_access_denied: "🚫 Доступ запрещён. Команда доступна только разработчику."
+      auth_required: "Сначала авторизуйтесь через /start"
     commands:
       error_occurred: "❌ Произошла ошибка. Мы уже работаем над её устранением."
       descriptions:


### PR DESCRIPTION
## Summary

- Исправлена ошибка "Произошла ошибка. Мы уже работаем над её устранением." при выборе проекта в команде `/users`
- Добавлена проверка `current_user.nil?` в callback_query методах:
  - `users_list_project_callback_query` — просмотр пользователей проекта
  - `users_add_project_callback_query` — добавление пользователя
  - `users_add_role_callback_query` — выбор роли
- Добавлен i18n ключ `telegram.errors.auth_required`
- Заменён хардкод текста на `t('errors.auth_required')`

## Причина ошибки

Метод `find_project` делегируется к `current_user` через `BaseCommand`. Когда пользователь нажимал кнопку выбора проекта, callback_query методы сразу вызывали `find_project()`, что приводило к `NoMethodError` если `current_user` был `nil`.

## Test plan

- [x] Все 19 тестов для `UsersCommand` проходят
- [ ] Проверить в Telegram: неавторизованный пользователь получает сообщение "Сначала авторизуйтесь через /start"

🤖 Generated with [Claude Code](https://claude.com/claude-code)